### PR TITLE
Add global styles varibles and theme with custom theme hoc

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -3,7 +3,7 @@ import type { Config } from '@jest/types';
 const config: Config.InitialOptions = {
   collectCoverage: true,
   collectCoverageFrom: ['src/**/*.ts', '!**/styled.ts'],
-  coveragePathIgnorePatterns: ['/node_modules/', '/build/', '/src/stories/'],
+  coveragePathIgnorePatterns: ['/node_modules/', '/build/', '/src/stories/', '/src/styles/'],
   coverageThreshold: {
     global: {
       branches: 70,

--- a/src/components/decorators/WithCustomTheme/index.tsx
+++ b/src/components/decorators/WithCustomTheme/index.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { ThemeProvider } from 'styled-components';
+
+import { GlobalStyles, defaultTheme } from '@styles/index';
+import { Colors, Theme } from '@styles/types';
+
+import { WithCustomThemeProps } from './types';
+
+export const withCustomTheme = <P extends object>(WrappedComponent: React.ComponentType<P>) => {
+  const WithCustomTheme = (props: P & WithCustomThemeProps) => {
+    const { customColors = {}, ...restProps } = props;
+
+    const mergedTheme: Theme = {
+      ...defaultTheme,
+      colors: { ...defaultTheme.colors, ...customColors } as Colors,
+    };
+
+    return (
+      <ThemeProvider theme={mergedTheme}>
+        <GlobalStyles />
+        <WrappedComponent {...(restProps as P)} />
+      </ThemeProvider>
+    );
+  };
+
+  WithCustomTheme.displayName = `WithCustomTheme(${WrappedComponent.displayName || WrappedComponent.name || 'Component'})`;
+
+  return WithCustomTheme;
+};

--- a/src/components/decorators/WithCustomTheme/types.ts
+++ b/src/components/decorators/WithCustomTheme/types.ts
@@ -1,0 +1,5 @@
+import { Colors } from '@styles/types';
+
+export interface WithCustomThemeProps {
+  customColors?: Partial<Colors>;
+}

--- a/src/components/decorators/__tests__/exports.test.ts
+++ b/src/components/decorators/__tests__/exports.test.ts
@@ -1,0 +1,13 @@
+import * as index from '@components/decorators';
+import { withCalendarView } from '@components/decorators/WithCalendarView';
+import { withCustomTheme } from '@components/decorators/WithCustomTheme';
+
+describe('components folder index file exports', () => {
+  it('should export withCalendarView from index', () => {
+    expect(index.withCalendarView).toBe(withCalendarView);
+  });
+
+  it('should export withCustomTheme from index', () => {
+    expect(index.withCustomTheme).toBe(withCustomTheme);
+  });
+});

--- a/src/components/decorators/index.ts
+++ b/src/components/decorators/index.ts
@@ -1,1 +1,2 @@
 export { withCalendarView } from './WithCalendarView';
+export { withCustomTheme } from './WithCustomTheme';

--- a/src/styles/global.ts
+++ b/src/styles/global.ts
@@ -1,0 +1,39 @@
+import { createGlobalStyle } from 'styled-components';
+
+export const GlobalStyles = createGlobalStyle`
+  * {
+    margin: 0;
+    padding: 0;
+    outline: 0;
+    box-sizing: border-box;
+    font-family: inherit;
+    transition: all .4s ease-out;
+  }
+
+  body {
+		font-family: 'Open Sans';
+		position: relative;
+	}
+
+  a {
+    color: inherit;
+    text-decoration: none;
+  }
+
+  input, button, textarea, select {
+    font: inherit;
+  }
+
+  p, h1, h2, h3, h4, h5, h6 {
+    overflow-wrap: break-word;
+  }
+
+  button {
+		background-color: transparent;
+		border: none;
+
+		&:hover {
+			cursor: pointer;
+		}
+	}
+`;

--- a/src/styles/index.ts
+++ b/src/styles/index.ts
@@ -1,0 +1,2 @@
+export { GlobalStyles } from './global';
+export { defaultTheme } from './theme';

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -1,0 +1,27 @@
+import {
+  borderWidth,
+  size,
+  spacing,
+  colors,
+  fontSize,
+  fontFamily,
+  fontWeight,
+  lineHeight,
+  borderRadius,
+} from '@styles/variables';
+
+export const defaultTheme = {
+  colors,
+  font: {
+    family: fontFamily,
+    height: lineHeight,
+    size: fontSize,
+    weight: fontWeight,
+  },
+  units: {
+    borderRadius,
+    borderWidth,
+    size,
+    spacing,
+  },
+};

--- a/src/styles/types.ts
+++ b/src/styles/types.ts
@@ -1,0 +1,7 @@
+import { defaultTheme } from './theme';
+
+export type Colors = typeof defaultTheme.colors;
+export type Font = typeof defaultTheme.font;
+export type Units = typeof defaultTheme.units;
+
+export type Theme = typeof defaultTheme;

--- a/src/styles/variables/colors.ts
+++ b/src/styles/variables/colors.ts
@@ -1,0 +1,12 @@
+export const colors = {
+  bgDayOnHover: 'rgba(241, 241, 241, 1)',
+  bgDaySelected: 'rgba(47, 128, 237, 1)',
+  bgRangeEnd: 'rgba(47, 128, 237, 1)',
+  bgRangeInBetween: 'rgba(47, 128, 237, 0.1)',
+  bgRangeStart: 'rgba(47, 128, 237, 0.6)',
+  disabledDayText: 'rgba(170, 170, 170, 1)',
+  primaryBorder: 'rgba(221, 221, 221, 1)',
+  primaryText: 'rgba(51, 51, 51, 1)',
+  rangeInBetweenText: 'rgba(47, 128, 237, 1)',
+  selectedDayText: 'rgba(255, 255, 255, 1)',
+};

--- a/src/styles/variables/fonts.ts
+++ b/src/styles/variables/fonts.ts
@@ -1,0 +1,25 @@
+export const fontWeight = {
+  bold: 700,
+  medium: 500,
+  regular: 400,
+  semiBold: 600,
+  thin: 300,
+};
+
+export const fontSize = {
+  heading: 20,
+  large: 15,
+  medium: 14,
+  reset: 13,
+  small: 12,
+};
+
+export const lineHeight = {
+  heading: 30,
+  large: 20,
+  medium: 18,
+};
+
+export const fontFamily = {
+  primary: 'Open Sans',
+};

--- a/src/styles/variables/index.ts
+++ b/src/styles/variables/index.ts
@@ -1,0 +1,3 @@
+export { colors } from './colors';
+export { fontFamily, fontSize, fontWeight, lineHeight } from './fonts';
+export { borderRadius, spacing, size, borderWidth } from './units';

--- a/src/styles/variables/units.ts
+++ b/src/styles/variables/units.ts
@@ -1,0 +1,28 @@
+export const borderRadius = {
+  large: 15,
+  medium: 8,
+  none: 0,
+  small: 3,
+};
+
+export const spacing = {
+  large: 15,
+  medium: 11,
+  small: 7,
+  xLarge: 13,
+  xMedium: 10,
+  xSmall: 6,
+  xxLarge: 12,
+  xxMedium: 8,
+  xxSmall: 5,
+};
+
+export const size = {
+  minCalerndarWidth: 250,
+};
+
+export const borderWidth = {
+  large: 4,
+  medium: 2,
+  thin: 1,
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,6 +20,7 @@
       "@/*": ["./src/*"],
       "@assets/*": ["./src/assets/*"],
       "@components/*": ["./src/components/*"],
+      "@styles/*": ["./src/styles/*"],
       "@type/*": ["./src/types/*"],
       "@services/*": ["./src/services/*"]
     }


### PR DESCRIPTION
# Description
This pull request introduces the addition of variables for a theme, as well as the corresponding objects to create a theme object. Types were added for the theme and its elements, as well as WithCustomTheme hoc to allow custom colours and customisation of the wrapped component

## Changes
- The following _variables objects_ have been added: 
  - colors
  - fontWeight
  - fontSize
  - lineHeight
  - fontFamily
  - borderRadius
  - spacing
  - size
  - borderWidth
- Added _theme_ object and types for theme properties (_colors_, _font_, _units_)
- Added global styles
- Added _WithCustomTheme_ hoc for managing theme and global style as well as ability to add custom theme colors for the wrapped component (uses default styles if custom colors are not added)
- Updated exports for decorators and styles folder
- Added tests for components decorators exports

## Checklist
- [x] Update jest and tsconfig
- [x] Add styles variables
- [x] Add global styles
- [x] Add types for theme
- [x] Add WithCustomTheme hoc

## Notes
Colours and other variables will be expanded and changed in the future as new functionality is added