### PR TITLE
Add Calendar component logic and Range Calendar component

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -17,6 +17,7 @@ const config: Config.InitialOptions = {
     '\\.(css|less|scss|sass)$': 'identity-obj-proxy',
     '^@assets/(.*)$': '<rootDir>/src/assets/$1',
     '^@components/(.*)$': '<rootDir>/src/components/$1',
+    '^@constants/(.*)$': '<rootDir>/src/constants/$1',
     '^@decorators/(.*)$': '<rootDir>/src/decorators/$1',
     '^@lib/(.*)$': '<rootDir>/src/lib/$1',
     '^@services/(.*)$': '<rootDir>/src/services/$1',

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -3,7 +3,14 @@ import type { Config } from '@jest/types';
 const config: Config.InitialOptions = {
   collectCoverage: true,
   collectCoverageFrom: ['src/**/*.ts', '!**/styled.ts'],
-  coveragePathIgnorePatterns: ['/node_modules/', '/build/', '/src/stories/', '/src/styles/', '/src/lib/theme'],
+  coveragePathIgnorePatterns: [
+    '/node_modules/',
+    '/build/',
+    '/src/stories/',
+    '/src/styles/',
+    '/src/lib/theme',
+    '/src/hooks/',
+  ],
   coverageThreshold: {
     global: {
       branches: 70,
@@ -19,6 +26,7 @@ const config: Config.InitialOptions = {
     '^@components/(.*)$': '<rootDir>/src/components/$1',
     '^@constants/(.*)$': '<rootDir>/src/constants/$1',
     '^@decorators/(.*)$': '<rootDir>/src/decorators/$1',
+    '^@hooks/(.*)$': '<rootDir>/src/hooks/$1',
     '^@lib/(.*)$': '<rootDir>/src/lib/$1',
     '^@services/(.*)$': '<rootDir>/src/services/$1',
     '^@styles/(.*)$': '<rootDir>/src/styles/$1',

--- a/src/components/Calendar/index.tsx
+++ b/src/components/Calendar/index.tsx
@@ -1,7 +1,227 @@
-import React from 'react';
+import { DateTime } from 'luxon';
+import React, { useEffect, useState } from 'react';
 
-import { Container } from './styled';
+import { CalendarItem as CalendarItemType } from '@components/CalendarItem/types';
+import { Modal, Input, Header, CalendarItem } from '@components/index';
+import {
+  generateMonthView,
+  generateWeekView,
+  generateYearView,
+  getCurrentDate,
+  getHeaders,
+  getRangeState,
+} from '@lib/calendar';
+import { Task, View } from '@type/index';
 
-export const Calendar = () => {
-  return <Container>Calendar</Container>;
+import { Button, CalendarWrapper, Container, CalendarItems } from './styled';
+import { CalendarProps } from './types';
+
+export const Calendar = ({
+  enableRange = false,
+  endRange,
+  holidays,
+  inputValue,
+  isOpen = false,
+  isWeekStartOnMonday = false,
+  label = 'Date',
+  maxDate,
+  minDate,
+  onDateSelect,
+  setView,
+  showWeekends = true,
+  startRange,
+  taskManager,
+  tasks,
+  view = View.Month,
+}: CalendarProps & { minDate?: DateTime; maxDate?: DateTime }) => {
+  const [isCalendarOpen, setIsCalendarOpen] = useState(isOpen);
+  const [currentDate, setCurrentDate] = useState<DateTime>(getCurrentDate());
+  const [days, setDays] = useState<CalendarItemType[]>([]);
+  const [selectedDate, setSelectedDate] = useState<DateTime | null>(null);
+  const [showModal, setShowModal] = useState(false);
+  const [input, setInput] = useState(inputValue || '');
+
+  const { headerDays, headerTitle } = getHeaders(currentDate, view, isWeekStartOnMonday, showWeekends);
+
+  useEffect(() => {
+    if (view === View.Month) {
+      setDays(
+        generateMonthView(currentDate.year, currentDate.month, minDate, maxDate, isWeekStartOnMonday, showWeekends)
+      );
+    }
+
+    if (view === View.Week) {
+      setDays(generateWeekView(currentDate, minDate, maxDate, isWeekStartOnMonday, showWeekends));
+    }
+
+    if (view === View.Year) {
+      setDays(generateYearView(currentDate.year, minDate, maxDate));
+    }
+  }, [currentDate, isWeekStartOnMonday, maxDate, minDate, showWeekends, view]);
+
+  const handleViewChange = () => {
+    setView?.();
+  };
+
+  const handleCalendarToggle = () => {
+    setIsCalendarOpen((prev) => !prev);
+  };
+
+  const handleCalendarInputFocus = () => {
+    setIsCalendarOpen(true);
+  };
+
+  const updateDate = (unit: View, amount: number) => {
+    const newDate = currentDate.plus({ [unit]: amount });
+
+    setCurrentDate(newDate);
+  };
+
+  const handleHeaderControlsClick = (isNextDate: boolean) => () => {
+    if (view === View.Month) {
+      updateDate(View.Month, isNextDate ? 1 : -1);
+    }
+
+    if (view === View.Week) {
+      updateDate(View.Week, isNextDate ? 1 : -1);
+    }
+
+    if (view === View.Year) {
+      updateDate(View.Year, isNextDate ? 5 : -5);
+    }
+  };
+
+  const handleItemClick = (item: CalendarItemType) => {
+    if (item.isDisabled) return;
+
+    const itemDate = item.date || currentDate;
+
+    setInput(itemDate.toFormat('yyyy-MM-dd'));
+    setSelectedDate(itemDate);
+    onDateSelect?.(itemDate);
+  };
+
+  const handleInputChange = (value: string) => {
+    setInput(value);
+
+    const parsedDate = DateTime.fromISO(value);
+
+    if (parsedDate.isValid) {
+      if ((!minDate || parsedDate >= minDate) && (!maxDate || parsedDate <= maxDate)) {
+        setCurrentDate(parsedDate);
+        setSelectedDate(parsedDate);
+
+        if (enableRange && value.length === 10) onDateSelect?.(parsedDate);
+      }
+    }
+  };
+
+  const handleItemDoubleClick = (item: CalendarItemType) => {
+    if (!taskManager) return;
+
+    if (!item.isDisabled) {
+      const itemDate = item.date || getCurrentDate();
+      setSelectedDate(itemDate);
+      setShowModal(true);
+    }
+  };
+
+  const handleCloseModal = () => {
+    setShowModal(false);
+  };
+
+  const handleAddTask = (taskName: string) => {
+    if (selectedDate) {
+      const newTask: Task = {
+        date: selectedDate.toISODate() || '',
+        done: false,
+        id: Date.now().toString(),
+        task: taskName,
+      };
+
+      taskManager?.addTask(newTask);
+    }
+  };
+
+  const handleUpdateTask = (task: Task) => {
+    taskManager?.updateTask(task);
+  };
+
+  const handleDeleteTask = (taskId: string) => {
+    if (selectedDate) {
+      taskManager?.deleteTask(selectedDate.toISODate() || '', taskId);
+    }
+  };
+
+  const handleClearInput = () => {
+    setInput('');
+    setSelectedDate(null);
+  };
+
+  return (
+    <>
+      <Modal
+        show={showModal}
+        tasks={tasks?.[selectedDate?.toISODate() || ''] || []}
+        onClose={handleCloseModal}
+        onAddTask={handleAddTask}
+        onDeleteTask={handleDeleteTask}
+        onUpdateTask={handleUpdateTask}
+      />
+      <Input
+        onFocus={handleCalendarInputFocus}
+        label={label}
+        name={label}
+        value={input}
+        onChange={handleInputChange}
+        toggleCalendar={handleCalendarToggle}
+      />
+      {isCalendarOpen && (
+        <Container>
+          <CalendarWrapper>
+            <Header
+              title={headerTitle}
+              handleNextClick={handleHeaderControlsClick(true)}
+              handlePrevClick={handleHeaderControlsClick(false)}
+              handleDateTitleClick={handleViewChange}
+            />
+            <CalendarItems $showWeekends={showWeekends} $viewType={view || View.Month}>
+              {view !== View.Year && headerDays.map((day) => <CalendarItem key={day} value={day} isHeaderItem />)}
+
+              {days.map(({ date = currentDate, isDisabled, rangeEnd, rangeInBetween, rangeStart, value }) => {
+                const holidaysForDate = holidays?.filter((holiday) =>
+                  DateTime.fromISO(holiday.startDate).hasSame(date, 'day')
+                );
+
+                const rangeState = getRangeState(enableRange, date, startRange, endRange);
+                const inBetweenRange = enableRange && startRange && endRange && date > startRange && date < endRange;
+
+                const isSelected = selectedDate && date.toFormat('yyyy-MM-dd') === selectedDate.toFormat('yyyy-MM-dd');
+
+                const hasTasks = Boolean(tasks?.[date?.toISODate() || '']?.length);
+
+                return (
+                  <CalendarItem
+                    onClick={handleItemClick}
+                    onDoubleClick={handleItemDoubleClick}
+                    date={date}
+                    key={date?.toISODate()}
+                    value={value}
+                    isDisabled={isDisabled}
+                    rangeStart={rangeState.rangeStart || rangeStart}
+                    rangeEnd={rangeState.rangeEnd || rangeEnd}
+                    selected={enableRange ? false : isSelected || false}
+                    rangeInBetween={inBetweenRange || rangeInBetween}
+                    hasTasks={hasTasks}
+                    holidays={holidaysForDate}
+                  />
+                );
+              })}
+            </CalendarItems>
+          </CalendarWrapper>
+          {!enableRange && <Button onClick={handleClearInput}>Clear</Button>}
+        </Container>
+      )}
+    </>
+  );
 };

--- a/src/components/Calendar/styled.ts
+++ b/src/components/Calendar/styled.ts
@@ -1,7 +1,63 @@
 import styled from 'styled-components';
 
+import { View } from '@type/index';
+
 export const Container = styled.div`
+  ${({ theme }) => `
+    min-width: ${theme.width.minCalerndar}px;
+    border: ${`${theme.size.smallX}px solid ${theme.colors.primaryBorder}`};
+    border-radius: ${theme.size.medium3X}px;
+  `}
+`;
+
+export const CalendarWrapper = styled.span`
   display: flex;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
+  text-align: center;
+
+  ${({ theme }) => `
+    width: ${theme.width.full};
+    padding: ${theme.size.large}px;
+  `}
+`;
+
+export const CalendarItems = styled.div<{ $showWeekends: boolean; $viewType: View }>`
+  display: grid;
+  grid-template-columns: ${({ $showWeekends, $viewType }) => {
+    if ($viewType === View.Year) {
+      return 'repeat(4, auto)';
+    }
+
+    return $showWeekends ? 'repeat(7, 1fr)' : 'repeat(5, 1fr)';
+  }};
+
+  ${({ $viewType }) => `
+    gap: ${$viewType === View.Year ? '10px' : '0px'};
+    & > div {
+      padding: ${$viewType === View.Year ? '5px' : '0px'};
+    }
+  `};
+
+  width: ${({ theme }) => theme.width.calendar}px;
+
+  align-items: center;
+  justify-content: center;
+  flex-wrap: wrap;
+`;
+
+export const Button = styled.button`
+  ${({ theme }) => `
+    width: ${theme.width.full};
+    border-top: ${`${theme.size.smallX}px solid ${theme.colors.primaryBorder}`};
+    border-radius: ${theme.size.reset} ${theme.size.reset} ${`${theme.size.medium3X}px ${theme.colors.medium3X}px`};
+    padding: ${theme.size.large}px;
+    font-size: ${theme.fontSize.small}px;
+    font-weight: ${theme.fontWeight.semiBold};
+
+    &:hover {
+      background: ${theme.colors.bgButtonOnHover};
+    }
+  `}
 `;

--- a/src/components/Calendar/types.ts
+++ b/src/components/Calendar/types.ts
@@ -1,6 +1,22 @@
-import { View } from '@type/index';
+import { DateTime } from 'luxon';
 
-export interface CalendarProps {
-  view?: View;
-  handleChangeView?: () => void;
+import { WithCalendarHolidaysProps } from '@decorators/WithCalendarHolidays/types';
+import { WithCalendarViewProps } from '@decorators/WithCalendarView/types';
+import { TaskManagerProps } from '@decorators/WithTaskManager/types';
+import { WithWeekendManagerProps } from '@decorators/WithWeekendManager/types';
+
+export interface CalendarProps
+  extends Partial<WithCalendarHolidaysProps>,
+    Partial<TaskManagerProps>,
+    Partial<WithCalendarViewProps>,
+    Partial<WithWeekendManagerProps> {
+  maxDate?: DateTime;
+  minDate?: DateTime;
+  isOpen?: boolean;
+  enableRange?: boolean;
+  startRange?: DateTime | null;
+  endRange?: DateTime | null;
+  inputValue?: string;
+  label: string;
+  onDateSelect?: (date: DateTime) => void;
 }

--- a/src/components/CalendarItem/styled.ts
+++ b/src/components/CalendarItem/styled.ts
@@ -26,40 +26,43 @@ export const CalendarItemWrapper = styled.div<{
   `}
 
   background: ${({ $rangeEnd, $rangeInBetween, $rangeStart, $selected, theme }) => {
-    if ($selected) return theme.colors.bgDaySelected;
+    if ($rangeStart && $rangeEnd) return theme.colors.bgDaySelected;
     if ($rangeStart) return theme.colors.bgRangeStart;
     if ($rangeEnd) return theme.colors.bgRangeEnd;
     if ($rangeInBetween) return theme.colors.bgRangeInBetween;
+    if ($selected) return theme.colors.bgDaySelected;
 
     return 'transparent';
   }};
 
   color: ${({ $isDisabled, $rangeEnd, $rangeInBetween, $rangeStart, $selected, theme }) => {
     if ($isDisabled) return theme.colors.disabledDayText;
-    if ($selected || $rangeStart || $rangeEnd) return theme.colors.selectedDayText;
     if ($rangeInBetween) return theme.colors.rangeInBetweenText;
+    if ($selected || $rangeStart || $rangeEnd) return theme.colors.selectedDayText;
 
     return theme.colors.primaryText;
   }};
 
   border-radius: ${({ $rangeEnd, $rangeInBetween, $rangeStart, $selected, theme }) => {
-    if ($selected) return `${theme.size.medium3X}px`;
+    if ($rangeStart && $rangeEnd) return `${theme.size.medium3X}px`;
     if ($rangeStart)
       return `${theme.size.medium3X}px ${theme.size.reset}px ${theme.size.reset}px ${theme.size.medium3X}px`;
     if ($rangeEnd)
       return `${theme.size.reset}px ${theme.size.medium3X}px ${theme.size.medium3X}px ${theme.size.reset}px`;
     if ($rangeInBetween) return `${theme.size.reset}px`;
+    if ($selected) return `${theme.size.medium3X}px`;
 
     return `${theme.size.reset}px`;
   }};
 
   &:hover {
     background: ${({ $isDisabled, $isHeaderItem, $rangeEnd, $rangeInBetween, $rangeStart, $selected, theme }) => {
-      if ($selected) return theme.colors.bgDaySelected;
+      if ($rangeStart && $rangeEnd) return theme.colors.bgDaySelected;
       if ($rangeStart) return theme.colors.bgRangeStart;
       if ($rangeEnd) return theme.colors.bgRangeEnd;
       if ($rangeInBetween) return theme.colors.bgRangeInBetween;
       if ($isHeaderItem || $isDisabled) return theme.colors.transparent;
+      if ($selected) return theme.colors.bgDaySelected;
 
       return theme.colors.bgButtonOnHover;
     }};

--- a/src/components/RangeCalendar/index.tsx
+++ b/src/components/RangeCalendar/index.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+
+import { CalendarWrapper } from '@components/CalendarWrapper';
+import { useRangeCalendar } from '@hooks/useRangeCalendar';
+
+import { RangeCalendarProps } from './types';
+
+const config = {
+  enableHolidays: false,
+  enableTasks: false,
+  enableViewToggle: true,
+  enableWeekends: true,
+};
+
+export const RangeCalendar = ({
+  className,
+  holidays,
+  isOpen,
+  isWeekStartOnMonday = false,
+  maxDate,
+  minDate,
+  showWeekends = true,
+  taskManager,
+  tasks,
+  view,
+}: RangeCalendarProps) => {
+  const { fromDate, handleFromDateChange, handleToDateChange, inputFromDate, inputToDate, toDate } = useRangeCalendar();
+
+  return (
+    <div className={className}>
+      <CalendarWrapper
+        config={config}
+        label="From"
+        enableRange
+        holidays={holidays}
+        isOpen={isOpen}
+        isWeekStartOnMonday={isWeekStartOnMonday}
+        maxDate={maxDate}
+        minDate={minDate}
+        showWeekends={showWeekends}
+        taskManager={taskManager}
+        tasks={tasks}
+        view={view}
+        startRange={fromDate}
+        endRange={toDate}
+        onDateSelect={handleFromDateChange}
+        inputValue={inputFromDate}
+      />
+      <CalendarWrapper
+        config={config}
+        label="To"
+        enableRange
+        holidays={holidays}
+        isOpen={isOpen}
+        isWeekStartOnMonday={isWeekStartOnMonday}
+        maxDate={maxDate}
+        minDate={minDate}
+        showWeekends={showWeekends}
+        taskManager={taskManager}
+        tasks={tasks}
+        view={view}
+        startRange={fromDate}
+        endRange={toDate}
+        onDateSelect={handleToDateChange}
+        inputValue={inputToDate}
+      />
+    </div>
+  );
+};

--- a/src/components/RangeCalendar/types.ts
+++ b/src/components/RangeCalendar/types.ts
@@ -1,0 +1,5 @@
+import { CalendarProps } from '../Calendar/types';
+
+export interface RangeCalendarProps extends CalendarProps {
+  className: string;
+}

--- a/src/components/RangeCalendar/types.ts
+++ b/src/components/RangeCalendar/types.ts
@@ -1,5 +1,5 @@
 import { CalendarProps } from '../Calendar/types';
 
 export interface RangeCalendarProps extends CalendarProps {
-  className: string;
+  className?: string;
 }

--- a/src/components/__tests__/exports.test.ts
+++ b/src/components/__tests__/exports.test.ts
@@ -1,8 +1,28 @@
-import { Calendar } from '@components/Calendar';
+import { CalendarItem } from '@components/CalendarItem';
+import { Header } from '@components/Header';
 import * as index from '@components/index';
+import { Input } from '@components/Input';
+import { Modal } from '@components/Modal';
+import { TaskContent } from '@components/TaskContent';
 
 describe('components folder index file exports', () => {
-  it('should export Calendar from index', () => {
-    expect(index.Calendar).toBe(Calendar);
+  it('should export CalendarItem from index', () => {
+    expect(index.CalendarItem).toBe(CalendarItem);
+  });
+
+  it('should export Header from index', () => {
+    expect(index.Header).toBe(Header);
+  });
+
+  it('should export Input from index', () => {
+    expect(index.Input).toBe(Input);
+  });
+
+  it('should export Modal from index', () => {
+    expect(index.Modal).toBe(Modal);
+  });
+
+  it('should export TaskContent from index', () => {
+    expect(index.TaskContent).toBe(TaskContent);
   });
 });

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,1 +1,5 @@
-export { Calendar } from './Calendar';
+export { CalendarItem } from './CalendarItem';
+export { Header } from './Header';
+export { Input } from './Input';
+export { Modal } from './Modal';
+export { TaskContent } from './TaskContent';

--- a/src/constants/calendar.ts
+++ b/src/constants/calendar.ts
@@ -1,0 +1,25 @@
+export const WEEK_DAYS_FROM_MON = ['Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa', 'Su'];
+
+export const WEEK_DAYS_FROM_SUN = ['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa'];
+
+export const MAX_CALENDAR_DAYS = 35;
+
+export const MAX_CALENDAR_DAYS_WITH_NEXT_MONTH = 42;
+
+export const MAX_CALENDAR_DAYS_WITHOUT_WEEKENDS = 25;
+
+export const WEEK_DAYS = 7;
+
+export const YEARS_INCREMENT = 5;
+
+export const MONTH_INCREMENT = 1;
+
+export const WEEK_INCREMENT = 1;
+
+export const DEFAULT_ITEM = {
+  isHeaderItem: false,
+  rangeEnd: false,
+  rangeInBetween: false,
+  rangeStart: false,
+  selected: false,
+};

--- a/src/decorators/WithCalendarView/index.tsx
+++ b/src/decorators/WithCalendarView/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo } from 'react';
+import React, { useState, useMemo, useCallback } from 'react';
 
 import { CalendarViewService } from '@services/CalendarViewService';
 import { View } from '@type/index';
@@ -9,24 +9,28 @@ export const withCalendarView = <P extends object>(
   WrappedComponent: React.ComponentType<P & WithCalendarViewProps>
 ) => {
   const WithCalendarView = (props: Omit<P, keyof WithCalendarViewProps> & CalendarViewServiceProps) => {
-    const { supportedViews, ...restProps } = props;
+    const { supportedViews = [View.Month], ...restProps } = props;
 
     const calendarViewService = useMemo(() => new CalendarViewService(supportedViews), [supportedViews]);
     const [view, setView] = useState(calendarViewService.getView());
 
-    const handleSetView = (newView: View) => {
-      calendarViewService.setView(newView);
-      setView(calendarViewService.getView());
-    };
+    const handleSetView = useCallback(
+      (newView: View) => {
+        calendarViewService.setView(newView);
 
-    return (
-      <WrappedComponent
-        {...(restProps as P)}
-        view={view}
-        setView={handleSetView}
-        availableViews={calendarViewService.getAvailableViews()}
-      />
+        setView(calendarViewService.getView());
+      },
+      [calendarViewService]
     );
+
+    const changeToNextView = useCallback(() => {
+      const nextIndex = (supportedViews.indexOf(view) + 1) % supportedViews.length;
+      const nextView = supportedViews[nextIndex];
+
+      handleSetView(nextView);
+    }, [view, supportedViews, handleSetView]);
+
+    return <WrappedComponent {...(restProps as P)} view={view} setView={changeToNextView} />;
   };
 
   WithCalendarView.displayName = `WithCalendarView(${WrappedComponent.displayName || WrappedComponent.name || 'Component'})`;

--- a/src/decorators/WithCalendarView/types.ts
+++ b/src/decorators/WithCalendarView/types.ts
@@ -2,10 +2,9 @@ import { View } from '@type/index';
 
 export interface WithCalendarViewProps {
   view: View;
-  setView: (view: View) => void;
-  availableViews: View[];
+  setView: () => void;
 }
 
 export interface CalendarViewServiceProps {
-  supportedViews: View[];
+  supportedViews?: View[];
 }

--- a/src/decorators/WithTaskManager/index.tsx
+++ b/src/decorators/WithTaskManager/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { TaskManagerService } from '@services/TaskManagerService';
 import { Task } from '@type/index';
@@ -7,15 +7,34 @@ import { TaskManagerProps } from './types';
 
 export const withTaskManager = <P extends object>(WrappedComponent: React.ComponentType<P & TaskManagerProps>) => {
   const WithTaskManager = (props: Omit<P, keyof TaskManagerProps>) => {
-    const taskManagerService = new TaskManagerService();
+    const [tasks, setTasks] = useState<Record<string, Task[]>>({});
+
+    const taskManagerService = useMemo(() => new TaskManagerService(), []);
+
+    const updateTasks = useCallback(() => {
+      setTasks(taskManagerService.getTasks());
+    }, [taskManagerService]);
+
+    useEffect(() => {
+      updateTasks();
+    }, [updateTasks]);
 
     const taskManager = {
-      addTask: (task: Task) => taskManagerService.addTask(task),
-      deleteTask: (date: string, taskId: string) => taskManagerService.deleteTask(date, taskId),
-      updateTask: (task: Task) => taskManagerService.updateTask(task),
+      addTask: (task: Task) => {
+        taskManagerService.addTask(task);
+        updateTasks();
+      },
+      deleteTask: (date: string, taskId: string) => {
+        taskManagerService.deleteTask(date, taskId);
+        updateTasks();
+      },
+      updateTask: (task: Task) => {
+        taskManagerService.updateTask(task);
+        updateTasks();
+      },
     };
 
-    return <WrappedComponent {...(props as P)} tasks={taskManagerService.getTasks()} taskManager={taskManager} />;
+    return <WrappedComponent {...(props as P)} tasks={tasks} taskManager={taskManager} />;
   };
 
   WithTaskManager.displayName = `WithTaskManager(${WrappedComponent.displayName || WrappedComponent.name || 'Component'})`;

--- a/src/hooks/useRangeCalendar.ts
+++ b/src/hooks/useRangeCalendar.ts
@@ -1,0 +1,33 @@
+import { DateTime } from 'luxon';
+import { useState } from 'react';
+
+export const useRangeCalendar = () => {
+  const [fromDate, setFromDate] = useState<DateTime | null>(null);
+  const [toDate, setToDate] = useState<DateTime | null>(null);
+
+  const handleFromDateChange = (date: DateTime) => {
+    if (toDate && date > toDate) {
+      setToDate(null);
+    }
+    setFromDate(date);
+  };
+
+  const handleToDateChange = (date: DateTime) => {
+    if (fromDate && date < fromDate) {
+      setFromDate(null);
+    }
+    setToDate(date);
+  };
+
+  const inputFromDate = fromDate?.toFormat('yyyy-MM-dd');
+  const inputToDate = toDate?.toFormat('yyyy-MM-dd');
+
+  return {
+    fromDate,
+    handleFromDateChange,
+    handleToDateChange,
+    inputFromDate,
+    inputToDate,
+    toDate,
+  };
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,13 @@
-import { Calendar } from '@components/index';
+import { DateTime } from 'luxon';
+
+import { CalendarWrapper } from '@components/CalendarWrapper';
+import { RangeCalendar } from '@components/RangeCalendar';
+import { Colors, Theme } from '@styles/types';
+import { Holiday, Task, View } from '@type/index';
+
+export type { Holiday, DateTime, Task, View, Colors, Theme };
 
 export default {
-  Calendar,
+  Calendar: CalendarWrapper,
+  RangeCalendar,
 };

--- a/src/lib/calendar/__tests__/exports.test.ts
+++ b/src/lib/calendar/__tests__/exports.test.ts
@@ -1,0 +1,38 @@
+import * as index from '@lib/calendar';
+import { generateMonthView } from '@lib/calendar/generateMonthView';
+import { generateWeekView } from '@lib/calendar/generateWeekView';
+import { generateYearView } from '@lib/calendar/generateYearView';
+import { getCurrentDate } from '@lib/calendar/getCurrentDate';
+import { getHeaders } from '@lib/calendar/getHeaders';
+import { getRangeState } from '@lib/calendar/getRangeState';
+import { getYearRange } from '@lib/calendar/getYearRange';
+
+describe('lib calendar folder index file exports', () => {
+  it('should export generateMonthView from index', () => {
+    expect(index.generateMonthView).toBe(generateMonthView);
+  });
+
+  it('should export generateWeekView from index', () => {
+    expect(index.generateWeekView).toBe(generateWeekView);
+  });
+
+  it('should export generateYearView from index', () => {
+    expect(index.generateYearView).toBe(generateYearView);
+  });
+
+  it('should export getCurrentDate from index', () => {
+    expect(index.getCurrentDate).toBe(getCurrentDate);
+  });
+
+  it('should export getYearRange from index', () => {
+    expect(index.getYearRange).toBe(getYearRange);
+  });
+
+  it('should export getHeaders from index', () => {
+    expect(index.getHeaders).toBe(getHeaders);
+  });
+
+  it('should export getRangeState from index', () => {
+    expect(index.getRangeState).toBe(getRangeState);
+  });
+});

--- a/src/lib/calendar/__tests__/generateMonthView.test.ts
+++ b/src/lib/calendar/__tests__/generateMonthView.test.ts
@@ -1,0 +1,64 @@
+import { DateTime } from 'luxon';
+
+import { DEFAULT_ITEM } from '@constants/calendar';
+import { generateMonthView } from '@lib/calendar';
+
+describe('generateMonthView', () => {
+  it('should generate a full month view including days from previous and next months', () => {
+    const result = generateMonthView(2024, 8);
+
+    expect(result.length).toBe(35);
+    expect(result[0].date.month).toBe(7);
+    expect(result[10].date.month).toBe(8);
+    expect(result[34].date.month).toBe(9);
+  });
+
+  it('should disable days before minDate and after maxDate', () => {
+    const minDate = DateTime.local(2024, 8, 10);
+    const maxDate = DateTime.local(2024, 8, 20);
+    const result = generateMonthView(2024, 8, minDate, maxDate);
+
+    expect(result.every((day) => (day.date < minDate ? day.isDisabled : true))).toBe(true);
+    expect(result.every((day) => (day.date > maxDate ? day.isDisabled : true))).toBe(true);
+    expect(result.some((day) => day.date.equals(minDate))).toBe(true);
+    expect(result.some((day) => day.date.equals(maxDate))).toBe(true);
+  });
+
+  it('should handle the startOnMonday flag correctly', () => {
+    const result = generateMonthView(2024, 8, undefined, undefined, false);
+
+    expect(result[0].date.weekday).toBe(7);
+  });
+
+  it('should exclude weekends when showWeekends is false', () => {
+    const result = generateMonthView(2024, 8, undefined, undefined, true, false);
+
+    expect(result.length).toBeLessThan(35);
+    expect(result.every((day) => day.date.weekday !== 6 && day.date.weekday !== 7)).toBe(true);
+  });
+
+  it('should handle both minDate and maxDate correctly by disabling days outside the range', () => {
+    const minDate = DateTime.local(2024, 8, 10);
+    const maxDate = DateTime.local(2024, 8, 20);
+    const result = generateMonthView(2024, 8, minDate, maxDate);
+
+    expect(result.length).toBe(35);
+    expect(result.find((day) => day.date.equals(minDate))?.isDisabled).toBe(false);
+    expect(result.find((day) => day.date.equals(maxDate))?.isDisabled).toBe(false);
+    expect(result.find((day) => day.date < minDate)?.isDisabled).toBe(true);
+    expect(result.find((day) => day.date > maxDate)?.isDisabled).toBe(true);
+  });
+
+  it('should return objects with the correct shape and values', () => {
+    const date = DateTime.local();
+    const result = generateMonthView(date.year, date.month);
+
+    result.forEach((day) => {
+      expect(day).toHaveProperty('date');
+      expect(day).toHaveProperty('isDisabled');
+      expect(day).toHaveProperty('key');
+      expect(day).toHaveProperty('value');
+      expect(day).toMatchObject(DEFAULT_ITEM);
+    });
+  });
+});

--- a/src/lib/calendar/__tests__/generateWeekView.test.ts
+++ b/src/lib/calendar/__tests__/generateWeekView.test.ts
@@ -1,0 +1,86 @@
+import { DateTime } from 'luxon';
+
+import { DEFAULT_ITEM } from '@constants/calendar';
+import { generateWeekView } from '@lib/calendar';
+
+describe('generateWeekView', () => {
+  it('should generate a full week starting on Monday', () => {
+    const startDate = DateTime.local(2024, 8, 21);
+    const result = generateWeekView(startDate);
+
+    expect(result.length).toBe(7);
+
+    expect(result[0].date.weekday).toBe(1);
+    expect(result[6].date.weekday).toBe(7);
+  });
+
+  it('should generate a full week starting on Sunday if startOnMonday is false', () => {
+    const startDate = DateTime.local(2024, 8, 21);
+    const result = generateWeekView(startDate, undefined, undefined, false);
+
+    expect(result.length).toBe(7);
+
+    expect(result[0].date.weekday).toBe(7);
+    expect(result[6].date.weekday).toBe(6);
+  });
+
+  it('should respect the minDate and disable days before it', () => {
+    const startDate = DateTime.local(2024, 8, 21);
+    const minDate = DateTime.local(2024, 8, 19);
+    const result = generateWeekView(startDate, minDate);
+
+    expect(result[0].isDisabled).toBe(false);
+    expect(result[1].isDisabled).toBe(false);
+    expect(result[2].isDisabled).toBe(false);
+  });
+
+  it('should exclude weekends if showWeekends is false', () => {
+    const startDate = DateTime.local(2024, 8, 19);
+    const result = generateWeekView(startDate, undefined, undefined, true, false);
+
+    expect(result.length).toBe(5);
+    expect(result[0].date.weekday).toBe(1);
+    expect(result[4].date.weekday).toBe(5);
+  });
+
+  it('should respect the maxDate and disable days after it', () => {
+    const startDate = DateTime.local(2024, 8, 21);
+    const maxDate = DateTime.local(2024, 8, 23);
+    const result = generateWeekView(startDate, undefined, maxDate);
+
+    expect(result.length).toBe(7);
+    expect(result[3].isDisabled).toBe(false);
+    expect(result[4].isDisabled).toBe(false);
+    expect(result[5].isDisabled).toBe(true);
+    expect(result[6].isDisabled).toBe(true);
+  });
+
+  it('should handle both minDate and maxDate correctly by disabling days outside the range', () => {
+    const startDate = DateTime.local(2024, 8, 19);
+    const minDate = DateTime.local(2024, 8, 20);
+    const maxDate = DateTime.local(2024, 8, 22);
+    const result = generateWeekView(startDate, minDate, maxDate);
+
+    expect(result.length).toBe(7);
+    expect(result[0].isDisabled).toBe(true);
+    expect(result[1].isDisabled).toBe(false);
+    expect(result[2].isDisabled).toBe(false);
+    expect(result[3].isDisabled).toBe(false);
+    expect(result[4].isDisabled).toBe(true);
+    expect(result[5].isDisabled).toBe(true);
+    expect(result[6].isDisabled).toBe(true);
+  });
+
+  it('should correctly assign default properties to each day item', () => {
+    const startDate = DateTime.local(2024, 8, 21);
+    const result = generateWeekView(startDate);
+
+    result.forEach((day) => {
+      expect(day).toMatchObject({
+        ...DEFAULT_ITEM,
+        key: day.date.toISODate(),
+        value: day.date.day,
+      });
+    });
+  });
+});

--- a/src/lib/calendar/__tests__/generateYearView.test.ts
+++ b/src/lib/calendar/__tests__/generateYearView.test.ts
@@ -1,0 +1,73 @@
+import { DateTime } from 'luxon';
+
+import { DEFAULT_ITEM } from '@constants/calendar';
+import { generateYearView } from '@lib/calendar';
+
+describe('generateYearView', () => {
+  it('should generate 11 years centered around the current year', () => {
+    const currentYear = 2024;
+    const result = generateYearView(currentYear);
+
+    expect(result.length).toBe(11);
+    expect(result[0].value).toBe((currentYear - 5).toString());
+    expect(result[10].value).toBe((currentYear + 5).toString());
+  });
+
+  it('should respect the minDate and not include years earlier than minDate', () => {
+    const currentYear = 2024;
+    const minDate = DateTime.local(2021, 1, 1);
+    const result = generateYearView(currentYear, minDate);
+
+    expect(result[0].value).toBe(minDate.year.toString());
+    expect(result).not.toContainEqual(expect.objectContaining({ value: (minDate.year - 1).toString() }));
+  });
+
+  it('should respect the maxDate and not include years later than maxDate', () => {
+    const currentYear = 2024;
+    const maxDate = DateTime.local(2026, 1, 1);
+    const result = generateYearView(currentYear, undefined, maxDate);
+
+    expect(result[result.length - 1].value).toBe(maxDate.year.toString());
+    expect(result).not.toContainEqual(expect.objectContaining({ value: (maxDate.year + 1).toString() }));
+  });
+
+  it('should respect both minDate and maxDate', () => {
+    const currentYear = 2024;
+    const minDate = DateTime.local(2022, 1, 1);
+    const maxDate = DateTime.local(2026, 1, 1);
+    const result = generateYearView(currentYear, minDate, maxDate);
+
+    expect(result[0].value).toBe(minDate.year.toString());
+    expect(result[result.length - 1].value).toBe(maxDate.year.toString());
+    expect(result).not.toContainEqual(expect.objectContaining({ value: (minDate.year - 1).toString() }));
+    expect(result).not.toContainEqual(expect.objectContaining({ value: (maxDate.year + 1).toString() }));
+  });
+
+  it('should disable years outside of the minDate and maxDate', () => {
+    const currentYear = 2024;
+    const minDate = DateTime.local(2023, 1, 1);
+    const maxDate = DateTime.local(2025, 1, 1);
+    const result = generateYearView(currentYear, minDate, maxDate);
+
+    result.forEach((year) => {
+      if (year.date.year < minDate.year || year.date.year > maxDate.year) {
+        expect(year.isDisabled).toBe(true);
+      } else {
+        expect(year.isDisabled).toBe(false);
+      }
+    });
+  });
+
+  it('should correctly assign default properties to each year item', () => {
+    const currentYear = 2024;
+    const result = generateYearView(currentYear);
+
+    result.forEach((year) => {
+      expect(year).toMatchObject({
+        ...DEFAULT_ITEM,
+        key: year.value,
+        value: year.value,
+      });
+    });
+  });
+});

--- a/src/lib/calendar/__tests__/getHeaders.test.ts
+++ b/src/lib/calendar/__tests__/getHeaders.test.ts
@@ -1,0 +1,98 @@
+import { DateTime } from 'luxon';
+
+import { WEEK_DAYS_FROM_MON, WEEK_DAYS_FROM_SUN } from '@constants/calendar';
+import { getHeaders } from '@lib/calendar/getHeaders';
+import { View } from '@type/index';
+
+describe('getHeaders', () => {
+  const testCases = [
+    {
+      date: DateTime.local(2024, 1, 15),
+      expectedDays: WEEK_DAYS_FROM_MON,
+      expectedTitle: 'January 2024',
+      isWeekStartOnMonday: true,
+      showWeekends: true,
+      view: View.Month,
+    },
+    {
+      date: DateTime.local(2023, 12, 1),
+      expectedDays: WEEK_DAYS_FROM_SUN,
+      expectedTitle: 'December 2023',
+      isWeekStartOnMonday: false,
+      showWeekends: true,
+      view: View.Month,
+    },
+    {
+      date: DateTime.local(2022, 6, 10),
+      expectedDays: WEEK_DAYS_FROM_MON.filter((day) => day !== 'Su' && day !== 'Sa'),
+      expectedTitle: 'June 2022',
+      isWeekStartOnMonday: true,
+      showWeekends: false,
+      view: View.Month,
+    },
+    {
+      date: DateTime.local(2021, 3, 25),
+      expectedDays: WEEK_DAYS_FROM_SUN.filter((day) => day !== 'Su' && day !== 'Sa'),
+      expectedTitle: 'March 2021',
+      isWeekStartOnMonday: false,
+      showWeekends: false,
+      view: View.Month,
+    },
+    {
+      date: DateTime.local(2024, 8, 25),
+      expectedDays: WEEK_DAYS_FROM_MON,
+      expectedTitle: '2024',
+      isWeekStartOnMonday: true,
+      showWeekends: true,
+      view: View.Year,
+    },
+    {
+      date: DateTime.local(2020, 5, 15),
+      expectedDays: WEEK_DAYS_FROM_SUN,
+      expectedTitle: '2020',
+      isWeekStartOnMonday: false,
+      showWeekends: true,
+      view: View.Year,
+    },
+    {
+      date: DateTime.local(2019, 7, 10),
+      expectedDays: WEEK_DAYS_FROM_MON,
+      expectedTitle: 'July 2019',
+      isWeekStartOnMonday: true,
+      showWeekends: true,
+      view: View.Month,
+    },
+    {
+      date: DateTime.local(2025, 11, 3),
+      expectedDays: WEEK_DAYS_FROM_SUN.filter((day) => day !== 'Su' && day !== 'Sa'),
+      expectedTitle: 'November 2025',
+      isWeekStartOnMonday: false,
+      showWeekends: false,
+      view: View.Month,
+    },
+    {
+      date: DateTime.local(2021, 2, 14),
+      expectedDays: WEEK_DAYS_FROM_MON,
+      expectedTitle: '2021',
+      isWeekStartOnMonday: true,
+      showWeekends: true,
+      view: View.Year,
+    },
+    {
+      date: DateTime.local(2022, 9, 30),
+      expectedDays: WEEK_DAYS_FROM_SUN,
+      expectedTitle: 'September 2022',
+      isWeekStartOnMonday: false,
+      showWeekends: true,
+      view: View.Month,
+    },
+  ];
+
+  testCases.forEach(({ date, expectedDays, expectedTitle, isWeekStartOnMonday, showWeekends, view }) => {
+    test(`returns correct headers for date ${date.toFormat('yyyy-MM-dd')} with view ${view}, week start on ${isWeekStartOnMonday ? 'Monday' : 'Sunday'}, ${showWeekends ? 'with' : 'without'} weekends`, () => {
+      const result = getHeaders(date, view, isWeekStartOnMonday, showWeekends);
+      expect(result.headerDays).toEqual(expectedDays);
+      expect(result.headerTitle).toBe(expectedTitle);
+    });
+  });
+});

--- a/src/lib/calendar/__tests__/getRangeState.test.ts
+++ b/src/lib/calendar/__tests__/getRangeState.test.ts
@@ -1,0 +1,71 @@
+import { DateTime } from 'luxon';
+
+import { getRangeState } from '@lib/calendar/getRangeState';
+
+describe('getRangeState', () => {
+  const date = DateTime.local(2024, 8, 25);
+
+  test('returns empty object when range is disabled', () => {
+    const result = getRangeState(false, date, DateTime.local(2024, 8, 20), DateTime.local(2024, 8, 30));
+    expect(result).toEqual({});
+  });
+
+  test('returns correct state when date is the start of the range', () => {
+    const startRange = DateTime.local(2024, 8, 25);
+    const endRange = DateTime.local(2024, 8, 30);
+    const result = getRangeState(true, date, startRange, endRange);
+    expect(result).toEqual({ rangeEnd: false, rangeInBetween: false, rangeStart: true });
+  });
+
+  test('returns correct state when date is the end of the range', () => {
+    const startRange = DateTime.local(2024, 8, 20);
+    const endRange = DateTime.local(2024, 8, 25);
+    const result = getRangeState(true, date, startRange, endRange);
+    expect(result).toEqual({ rangeEnd: true, rangeInBetween: false, rangeStart: false });
+  });
+
+  test('returns correct state when date is between start and end of the range', () => {
+    const startRange = DateTime.local(2024, 8, 20);
+    const endRange = DateTime.local(2024, 8, 30);
+    const result = getRangeState(true, date, startRange, endRange);
+    expect(result).toEqual({ rangeEnd: false, rangeInBetween: true, rangeStart: false });
+  });
+
+  test('returns correct state when date is outside the range', () => {
+    const startRange = DateTime.local(2024, 8, 20);
+    const endRange = DateTime.local(2024, 8, 24);
+    const result = getRangeState(true, date, startRange, endRange);
+    expect(result).toEqual({ rangeEnd: false, rangeInBetween: false, rangeStart: false });
+  });
+
+  test('returns correct state when only startRange is provided and matches the date', () => {
+    const startRange = DateTime.local(2024, 8, 25);
+    const result = getRangeState(true, date, startRange, null);
+    expect(result).toEqual({ rangeEnd: null, rangeInBetween: null, rangeStart: true });
+  });
+
+  test('returns correct state when only endRange is provided and matches the date', () => {
+    const endRange = DateTime.local(2024, 8, 25);
+    const result = getRangeState(true, date, null, endRange);
+    expect(result).toEqual({ rangeEnd: true, rangeInBetween: null, rangeStart: null });
+  });
+
+  test('returns correct state when both startRange and endRange are null', () => {
+    const result = getRangeState(true, date, null, null);
+    expect(result).toEqual({ rangeEnd: null, rangeInBetween: null, rangeStart: null });
+  });
+
+  test('returns correct state when date is before the startRange', () => {
+    const startRange = DateTime.local(2024, 8, 26);
+    const endRange = DateTime.local(2024, 8, 30);
+    const result = getRangeState(true, date, startRange, endRange);
+    expect(result).toEqual({ rangeEnd: false, rangeInBetween: false, rangeStart: false });
+  });
+
+  test('returns correct state when date is after the endRange', () => {
+    const startRange = DateTime.local(2024, 8, 20);
+    const endRange = DateTime.local(2024, 8, 24);
+    const result = getRangeState(true, date, startRange, endRange);
+    expect(result).toEqual({ rangeEnd: false, rangeInBetween: false, rangeStart: false });
+  });
+});

--- a/src/lib/calendar/generateMonthView.ts
+++ b/src/lib/calendar/generateMonthView.ts
@@ -1,0 +1,79 @@
+import { DateTime } from 'luxon';
+
+import { DEFAULT_ITEM } from '@constants/calendar';
+
+export const generateMonthView = (
+  year: number,
+  month: number,
+  minDate?: DateTime | null,
+  maxDate?: DateTime | null,
+  startOnMonday: boolean = true,
+  showWeekends: boolean = true
+) => {
+  const startOfMonth = DateTime.local(year, month, 1);
+  const endOfMonth = startOfMonth.endOf('month');
+
+  let startWeekday = startOfMonth.weekday;
+  let endWeekday = endOfMonth.weekday;
+
+  if (startOnMonday) {
+    startWeekday -= 1;
+    endWeekday -= 1;
+  } else {
+    startWeekday %= 7;
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    endWeekday %= 7;
+  }
+
+  const daysInMonth = endOfMonth.day;
+  const daysArray = [];
+
+  const previousMonthEnd = startOfMonth.minus({ days: startWeekday });
+  const nextMonthStart = endOfMonth.plus({ days: 1 });
+
+  const totalDays = showWeekends ? 35 : 25;
+
+  for (let i = 0; i < startWeekday; i += 1) {
+    const day = previousMonthEnd.plus({ days: i });
+    if (showWeekends || (day.weekday !== 6 && day.weekday !== 7)) {
+      daysArray.push({
+        ...DEFAULT_ITEM,
+        date: day,
+        isDisabled: true,
+        key: day.toISODate(),
+        value: day.day,
+      });
+    }
+  }
+
+  for (let i = 1; i <= daysInMonth; i += 1) {
+    const day = startOfMonth.plus({ days: i - 1 });
+    const isDisabled = (minDate && day < minDate) || (maxDate && day > maxDate) || false;
+    if (showWeekends || (day.weekday !== 6 && day.weekday !== 7)) {
+      daysArray.push({
+        ...DEFAULT_ITEM,
+        date: day,
+        isDisabled,
+        key: day.toISODate(),
+        value: day.day,
+      });
+    }
+  }
+
+  let i = 1;
+  while (daysArray.length < totalDays) {
+    const day = nextMonthStart.plus({ days: i - 1 });
+    if (showWeekends || (day.weekday !== 6 && day.weekday !== 7)) {
+      daysArray.push({
+        ...DEFAULT_ITEM,
+        date: day,
+        isDisabled: true,
+        key: day.toISODate(),
+        value: day.day,
+      });
+    }
+    i += 1;
+  }
+
+  return daysArray;
+};

--- a/src/lib/calendar/generateWeekView.ts
+++ b/src/lib/calendar/generateWeekView.ts
@@ -1,0 +1,40 @@
+import { DateTime } from 'luxon';
+
+import { DEFAULT_ITEM } from '@constants/calendar';
+
+export const generateWeekView = (
+  startDate: DateTime,
+  minDate?: DateTime,
+  maxDate?: DateTime,
+  startOnMonday: boolean = true,
+  showWeekends: boolean = true
+) => {
+  const daysArray = [];
+  let dayOfWeek = startDate.weekday;
+
+  if (startOnMonday) {
+    dayOfWeek -= 1;
+  } else {
+    dayOfWeek %= 7;
+  }
+
+  const weekStartDate = startDate.minus({ days: dayOfWeek });
+
+  for (let i = 0; i < 7; i += 1) {
+    const day = weekStartDate.plus({ days: i });
+    const isBeforeMinDate = minDate ? day < minDate : false;
+    const isAfterMaxDate = maxDate ? day > maxDate : false;
+
+    if (showWeekends || (day.weekday !== 6 && day.weekday !== 7)) {
+      daysArray.push({
+        ...DEFAULT_ITEM,
+        date: day,
+        isDisabled: isBeforeMinDate || isAfterMaxDate,
+        key: day.toISODate(),
+        value: day.day,
+      });
+    }
+  }
+
+  return daysArray;
+};

--- a/src/lib/calendar/generateYearView.ts
+++ b/src/lib/calendar/generateYearView.ts
@@ -1,0 +1,21 @@
+import { DateTime } from 'luxon';
+
+import { DEFAULT_ITEM } from '@constants/calendar';
+
+export const generateYearView = (currentYear: number, minDate?: DateTime, maxDate?: DateTime) => {
+  const yearsArray = [];
+  const startYear = Math.max(currentYear - 5, minDate ? minDate.year : -Infinity);
+  const endYear = Math.min(currentYear + 5, maxDate ? maxDate.year : Infinity);
+
+  for (let year = startYear; year <= endYear; year += 1) {
+    yearsArray.push({
+      ...DEFAULT_ITEM,
+      date: DateTime.local(year, 1, 1),
+      isDisabled: (minDate && year < minDate.year) || (maxDate && year > maxDate.year),
+      key: year.toString(),
+      value: year.toString(),
+    });
+  }
+
+  return yearsArray;
+};

--- a/src/lib/calendar/getCurrentDate.ts
+++ b/src/lib/calendar/getCurrentDate.ts
@@ -1,0 +1,3 @@
+import { DateTime } from 'luxon';
+
+export const getCurrentDate = () => DateTime.local();

--- a/src/lib/calendar/getHeaders.ts
+++ b/src/lib/calendar/getHeaders.ts
@@ -1,0 +1,13 @@
+import { DateTime } from 'luxon';
+
+import { WEEK_DAYS_FROM_MON, WEEK_DAYS_FROM_SUN } from '@constants/calendar';
+import { View } from '@type/index';
+
+export const getHeaders = (currentDate: DateTime, view: View, isWeekStartOnMonday: boolean, showWeekends: boolean) => {
+  let headerDays = isWeekStartOnMonday ? WEEK_DAYS_FROM_MON : WEEK_DAYS_FROM_SUN;
+  if (!showWeekends) headerDays = headerDays.filter((day) => day !== 'Su' && day !== 'Sa');
+
+  const headerTitle = view === View.Year ? currentDate.toFormat('yyyy') : currentDate.toFormat('MMMM yyyy');
+
+  return { headerDays, headerTitle };
+};

--- a/src/lib/calendar/getRangeState.ts
+++ b/src/lib/calendar/getRangeState.ts
@@ -1,0 +1,20 @@
+import { DateTime } from 'luxon';
+
+export const getRangeState = (
+  enableRange: boolean,
+  date: DateTime,
+  startRange?: DateTime | null,
+  endRange?: DateTime | null
+) => {
+  if (!enableRange) return {};
+
+  const isStart = startRange && date.equals(startRange);
+  const isEnd = endRange && date.equals(endRange);
+  const isInRange = startRange && endRange && date >= startRange && date <= endRange;
+
+  return {
+    rangeEnd: isEnd,
+    rangeInBetween: isInRange && !isStart && !isEnd,
+    rangeStart: isStart,
+  };
+};

--- a/src/lib/calendar/index.ts
+++ b/src/lib/calendar/index.ts
@@ -1,0 +1,7 @@
+export { generateMonthView } from './generateMonthView';
+export { generateWeekView } from './generateWeekView';
+export { generateYearView } from './generateYearView';
+export { getCurrentDate } from './getCurrentDate';
+export { getYearRange } from './getYearRange';
+export { getHeaders } from './getHeaders';
+export { getRangeState } from './getRangeState';

--- a/src/stories/Calendar.stories.tsx
+++ b/src/stories/Calendar.stories.tsx
@@ -1,30 +1,133 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import React from 'react';
 
-import { Calendar } from '@components/index';
-import { withCustomTheme } from '@decorators/index';
+import { CalendarWrapper } from '@components/CalendarWrapper';
+import { View } from '@type/index';
+
+import { defaultConfig, defaultCustomHolidays, defaultRange } from './defaults';
 
 const meta = {
-  args: {},
-  argTypes: {},
-  component: Calendar,
-  decorators: [
-    (Story) => {
-      const WrappedStory = withCustomTheme(Story);
-
-      return <WrappedStory />;
-    },
-  ],
+  component: CalendarWrapper,
   parameters: {
     layout: 'centered',
   },
   tags: ['autodocs'],
   title: 'Datepicker/Calendar',
-} satisfies Meta<typeof Calendar>;
+} satisfies Meta<typeof CalendarWrapper>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const CalendarView: Story = {
-  args: {},
+export const Default: Story = {
+  args: {
+    config: defaultConfig,
+    ...defaultRange,
+    isOpen: false,
+    isWeekStartOnMonday: false,
+    label: 'Date',
+    showWeekends: true,
+  },
+};
+
+export const ViewWithCustomHolidays: Story = {
+  args: {
+    config: {
+      ...defaultConfig,
+      enableHolidays: true,
+    },
+    ...defaultRange,
+    ...defaultCustomHolidays,
+    isOpen: true,
+    isWeekStartOnMonday: false,
+    label: 'Date',
+    showWeekends: true,
+    supportedViews: [View.Month, View.Year, View.Week],
+  },
+};
+
+export const ViewWithoutDefaultHolidays: Story = {
+  args: {
+    config: {
+      ...defaultConfig,
+      enableHolidays: true,
+    },
+    ...defaultRange,
+    ...defaultCustomHolidays,
+    includeDefaultHolidays: false,
+    isOpen: true,
+    isWeekStartOnMonday: false,
+    label: 'Date',
+    showWeekends: true,
+    supportedViews: [View.Month, View.Year, View.Week],
+  },
+};
+
+export const ViewWithTasks: Story = {
+  args: {
+    config: {
+      ...defaultConfig,
+      enableTasks: true,
+    },
+    ...defaultRange,
+    isOpen: true,
+    isWeekStartOnMonday: false,
+    label: 'Date',
+    showWeekends: true,
+    supportedViews: [View.Month, View.Year, View.Week],
+  },
+};
+
+export const WithViewToggle: Story = {
+  args: {
+    config: {
+      ...defaultConfig,
+      enableViewToggle: true,
+    },
+    ...defaultRange,
+    isOpen: true,
+    label: 'Date',
+    supportedViews: [View.Month, View.Year, View.Week],
+  },
+};
+
+export const ViewWeekends: Story = {
+  args: {
+    config: {
+      ...defaultConfig,
+      enableWeekends: true,
+    },
+    ...defaultRange,
+    isOpen: true,
+    isWeekStartOnMonday: false,
+    label: 'Date',
+    showWeekends: true,
+  },
+};
+
+export const ViewWeekStartOnModay: Story = {
+  args: {
+    config: {
+      ...defaultConfig,
+      enableWeekends: true,
+    },
+    ...defaultRange,
+    isOpen: true,
+    isWeekStartOnMonday: true,
+    label: 'Date',
+    showWeekends: true,
+  },
+};
+
+export const ViewNoWeekends: Story = {
+  args: {
+    config: {
+      ...defaultConfig,
+      enableWeekends: true,
+    },
+    ...defaultRange,
+    isOpen: true,
+    isWeekStartOnMonday: false,
+    label: 'Date',
+    showWeekends: false,
+    supportedViews: [View.Month, View.Year, View.Week],
+  },
 };

--- a/src/stories/CalendarRange.stories.tsx
+++ b/src/stories/CalendarRange.stories.tsx
@@ -1,0 +1,27 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { RangeCalendar } from '@components/RangeCalendar';
+import { getCurrentDate } from '@lib/calendar/getCurrentDate';
+
+const meta = {
+  args: {},
+  component: RangeCalendar,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  title: 'Datepicker/CalendarRange',
+} satisfies Meta<typeof RangeCalendar>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const CalendarView: Story = {
+  args: {
+    isWeekStartOnMonday: false,
+    label: 'RangeDate',
+    maxDate: getCurrentDate().plus({ years: 1 }),
+    minDate: getCurrentDate().minus({ years: 1 }),
+    showWeekends: true,
+  },
+};

--- a/src/stories/defaults.ts
+++ b/src/stories/defaults.ts
@@ -1,0 +1,30 @@
+import { getCurrentDate } from '@lib/calendar/getCurrentDate';
+
+export const defaultConfig = {
+  enableHolidays: false,
+  enableTasks: false,
+  enableViewToggle: false,
+  enableWeekends: false,
+};
+
+export const defaultRange = {
+  maxDate: getCurrentDate().plus({ years: 1 }),
+  minDate: getCurrentDate().minus({ years: 1 }),
+};
+
+export const defaultCustomHolidays = {
+  customHolidays: [
+    {
+      endDate: '2024-08-22',
+      id: '12345',
+      name: 'Random Holiday',
+      startDate: '2024-08-22',
+    },
+    {
+      endDate: '2024-08-22',
+      id: '1234',
+      name: 'Random Holiday 2',
+      startDate: '2024-08-22',
+    },
+  ],
+};

--- a/src/styles/types.ts
+++ b/src/styles/types.ts
@@ -1,7 +1,5 @@
 import { defaultTheme } from './theme';
 
 export type Colors = typeof defaultTheme.colors;
-export type Font = typeof defaultTheme.font;
-export type Units = typeof defaultTheme.units;
 
 export type Theme = typeof defaultTheme;

--- a/src/styles/variables/units.ts
+++ b/src/styles/variables/units.ts
@@ -15,6 +15,7 @@ export const size = {
 };
 
 export const width = {
+  calendar: 230,
   calendarItem: 32,
   full: '100%',
   half: '50%',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,6 +22,7 @@
       "@components/*": ["./src/components/*"],
       "@styles/*": ["./src/styles/*"],
       "@type/*": ["./src/types/*"],
+      "@constants/*": ["./src/constants/*"],
       "@decorators/*": ["./src/decorators/*"],
       "@lib/*": ["./src/lib/*"],
       "@services/*": ["./src/services/*"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,6 +24,7 @@
       "@type/*": ["./src/types/*"],
       "@constants/*": ["./src/constants/*"],
       "@decorators/*": ["./src/decorators/*"],
+      "@hooks/*": ["./src/hooks/*"],
       "@lib/*": ["./src/lib/*"],
       "@services/*": ["./src/services/*"]
     }


### PR DESCRIPTION
# Description
This pull request introduces the addition of the Calendar component logic, as well as the addition of a new Range Calendar component. Storie has been updated, as well as exports from the library. New utils as well as hooks have been added to encapsulate logic from components. New tests have been added as well

## Changes
- _Decorators updates_:
  - Updated WithCalendarView decorator to include the logic of changing the view based on the supported view to remove this logic from the components
  - Updated WithCalendarView props types to remove availableViews
  - Previously store wasn't updated after adding deleting or updating the tasks in local storage. Updated WithTaskManager decorators taskManager to include update and to memo the service class
- Added _new relative paths_ to tsconfig and jest config:
  - constants
  - hooks 
- Added calendar constants
- Added Calendar component logic and Range Calendar component
- Updated lib exports that include components and types now
- Implemented the following functions:
  - generateMonthView
  - generateWeekView
  - generateYearView
  - getCurrentDate
  - getHeaders
  - getRangeState
- Added the following stories for the calendars:
  - Default
  - ViewWithCustomHolidays
  - ViewWithoutDefaultHolidays
  - ViewWithTasks
  - WithViewToggle
  - ViewWeekends
  - ViewWeekStartOnModay
  - ViewNoWeekends
  - CalendarView (RangeCalendar)

## Checklist
- [x] Add Calendar component
- [x] Add Range Calendar component
- [x] Add and update tests
- [x] Update stories 

## Notes
Components will be refactored shortly